### PR TITLE
[FIX] remove field_get compatibility methods

### DIFF
--- a/account_peppol_backport/models/account_move.py
+++ b/account_peppol_backport/models/account_move.py
@@ -28,19 +28,6 @@ class AccountMove(models.Model):
     )
     peppol_is_demo_uuid = fields.Boolean(compute="_compute_peppol_is_demo_uuid")
 
-    @api.model
-    def fields_get(self, allfields=None, attributes=None):
-        res = super().fields_get(allfields, attributes)
-
-        # the orm_cache does not contain the new selections added in stable: clear the cache once
-        peppol_move_state_field = self._fields['peppol_move_state']
-        if ('skipped', "Skipped") not in peppol_move_state_field.get_description(self.env)['selection']:
-            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
-            self.env['ir.model.fields.selection']._update_selection(
-                'account.move', 'peppol_move_state', peppol_move_state_field.selection)
-            self.env.registry.clear_cache()
-        return res
-
     def action_cancel_peppol_documents(self):
         # if the peppol_move_state is processing/done
         # then it means it has been already sent to peppol proxy and we can't cancel

--- a/account_peppol_backport/models/res_partner.py
+++ b/account_peppol_backport/models/res_partner.py
@@ -55,30 +55,6 @@ class ResPartner(models.Model):
             create_column(self.env.cr, 'res_partner', 'account_peppol_validity_last_check', 'timestamp')
         return super()._auto_init()
 
-    @api.model
-    def fields_get(self, allfields=None, attributes=None):
-        # TODO: remove in master
-        res = super().fields_get(allfields, attributes)
-
-        # the orm_cache does not contain the new selections added in stable: clear the cache once
-        existing_selection = res.get('account_peppol_verification_label', {}).get('selection')
-        if existing_selection is None:
-            return res
-
-        not_valid_format_label = next(x for x in self._fields['account_peppol_verification_label'].selection if x[0] == 'not_valid_format')
-        need_update = not_valid_format_label not in existing_selection
-
-        if need_update:
-            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
-            self.env['ir.model.fields.selection']._update_selection(
-                'res.partner',
-                'account_peppol_verification_label',
-                self._fields['account_peppol_verification_label'].selection,
-            )
-            self.env.registry.clear_cache()
-            return super().fields_get(allfields, attributes)
-        return res
-
     # -------------------------------------------------------------------------
     # HELPER METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Their were there apparently for the needs of Odoo stable policy in 17 and are not compatible with 16.