### PR TITLE
[16.0][IMP] ensure order reference is always set

### DIFF
--- a/account_peppol_send_format_odoo/models/__init__.py
+++ b/account_peppol_send_format_odoo/models/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from . import account_edi_xml_ubl_20
 from . import account_edi_xml_ubl_bis3

--- a/account_peppol_send_format_odoo/models/account_edi_xml_ubl_20.py
+++ b/account_peppol_send_format_odoo/models/account_edi_xml_ubl_20.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import models
+
+
+class AccountEDIXMLUBL20(models.AbstractModel):
+    _inherit = "account.edi.xml.ubl_20"
+
+    def _export_invoice_vals(self, invoice):
+        # set order_reference in the same way as in odoo 17.0
+        vals = super()._export_invoice_vals(invoice)
+        if not vals["vals"]["order_reference"]:
+            vals["vals"]["order_reference"] = invoice.name
+        return vals


### PR DESCRIPTION
set the order reference in the same way as in odoo 17.0. differences: [16.0](https://github.com/OCA/OCB/blob/16.0/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L499), [17.0](https://github.com/OCA/OCB/blob/17.0/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L597).