### PR TITLE
[16.0][FIX] accont_edi_proxy_client_peppol: fix neutralize query

### DIFF
--- a/account_edi_proxy_client_peppol/data/neutralize.sql
+++ b/account_edi_proxy_client_peppol/data/neutralize.sql
@@ -1,1 +1,1 @@
-UPDATE account_edi_proxy_client_peppol_user SET edi_mode 'test';
+UPDATE account_edi_proxy_client_peppol_user SET edi_mode = 'test';

--- a/account_peppol_send_format_odoo/README.rst
+++ b/account_peppol_send_format_odoo/README.rst
@@ -61,10 +61,10 @@ Authors
 Contributors
 ------------
 
-- Stéphane Bidoul stephane.bidoul@acsone.eu
-- `Coop IT Easy SC <https://coopiteasy.be>`__:
+-  Stéphane Bidoul stephane.bidoul@acsone.eu
+-  `Coop IT Easy SC <https://coopiteasy.be>`__:
 
-  - hugues de keyzer
+   -  hugues de keyzer
 
 Other credits
 -------------


### PR DESCRIPTION
A '=' was missing in the query of the neutralize for it to be able to work.