### PR TITLE
[FIX] ..proxy_client..: fix syntax error in neutralize.sql

### DIFF
--- a/account_edi_proxy_client_peppol/data/neutralize.sql
+++ b/account_edi_proxy_client_peppol/data/neutralize.sql
@@ -1,1 +1,1 @@
-UPDATE account_edi_proxy_client_peppol_user SET edi_mode 'test';
+UPDATE account_edi_proxy_client_peppol_user SET edi_mode = 'test';


### PR DESCRIPTION
SQL column assignment needs an '='.