### PR TITLE
[16.0][FIX] neutralize by using demo mode

### DIFF
--- a/account_edi_proxy_client_peppol/data/neutralize.sql
+++ b/account_edi_proxy_client_peppol/data/neutralize.sql
@@ -1,1 +1,1 @@
-UPDATE account_edi_proxy_client_peppol_user SET edi_mode = 'test';
+UPDATE account_edi_proxy_client_peppol_user SET edi_mode = 'demo';


### PR DESCRIPTION
use demo mode instead of test mode when neutralizing. in test mode, documents will try to be sent and received on the peppol test network using the credentials of the live one, which will fail. the test network requires a separate registration.

this is the same behavior as in odoo 17.0.