### PR TITLE
[16.0][IMP] backport registration from 18.0

### DIFF
--- a/account_peppol_backport/__manifest__.py
+++ b/account_peppol_backport/__manifest__.py
@@ -4,7 +4,7 @@
     'name': "Peppol",
     'summary': "This module is used to register with the Odoo SA PEPPOL access point",
     'category': 'Accounting/Accounting',
-    'version': '16.0.1.0.0',
+    'version': '16.0.2.0.0',
     'depends': [
         'account_peppol_partner',
         'account_edi_proxy_client_peppol',

--- a/account_peppol_backport/data/cron.xml
+++ b/account_peppol_backport/data/cron.xml
@@ -22,8 +22,8 @@
 
     <record id="ir_cron_peppol_get_participant_status" model="ir.cron">
         <field name="name">PEPPOL: update participant status</field>
-        <field name="interval_number">6</field>
-        <field name="interval_type">hours</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">weeks</field>
         <field name="numbercall">-1</field>
         <field name="model_id" ref="model_account_edi_proxy_client_peppol_user"/>
         <field name="code">model._cron_peppol_get_participant_status()</field>

--- a/account_peppol_backport/migrations/16.0.2.0.0/pre-convert_proxy_state.py
+++ b/account_peppol_backport/migrations/16.0.2.0.0/pre-convert_proxy_state.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        update res_company
+        set account_peppol_proxy_state = case
+            when account_peppol_proxy_state in ('not_verified', 'sent_verification', 'canceled') then 'not_registered'
+            when account_peppol_proxy_state = 'pending' then 'smp_registration'
+            when account_peppol_proxy_state = 'active' then 'receiver'
+        end
+        where account_peppol_proxy_state in ('not_verified', 'sent_verification', 'pending', 'active', 'canceled')
+        """,
+    )

--- a/account_peppol_backport/models/account_edi_proxy_user.py
+++ b/account_peppol_backport/models/account_edi_proxy_user.py
@@ -262,7 +262,7 @@ class AccountEdiProxyClientPeppolUser(models.Model):
             self.env.ref('account_peppol_backport.ir_cron_peppol_get_message_status')._trigger()
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification']), ('proxy_type', '=', 'peppol')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '!=', 'not_registered'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
 
     def _peppol_get_participant_status(self):

--- a/account_peppol_backport/models/account_edi_proxy_user.py
+++ b/account_peppol_backport/models/account_edi_proxy_user.py
@@ -3,7 +3,7 @@
 import logging
 from base64 import b64encode
 
-from odoo import _, fields, models, modules, tools
+from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError
 
 from odoo.addons.account_edi_proxy_client_peppol.models.account_edi_proxy_user import (
@@ -64,16 +64,21 @@ class AccountEdiProxyClientPeppolUser(models.Model):
         }
         return urls
 
+    @api.model
+    def _get_can_send_domain(self):
+        return ('sender', 'smp_registration', 'receiver')
+
     # -------------------------------------------------------------------------
     # CRONS
     # -------------------------------------------------------------------------
 
     def _cron_peppol_get_new_documents(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active'), ('proxy_type', '=', 'peppol')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'receiver'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_new_documents()
 
     def _cron_peppol_get_message_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active'), ('proxy_type', '=', 'peppol')])
+        can_send = self.env['account_edi_proxy_client_peppol.user']._get_can_send_domain()
+        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', can_send), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_message_status()
 
     # -------------------------------------------------------------------------
@@ -262,27 +267,46 @@ class AccountEdiProxyClientPeppolUser(models.Model):
             self.env.ref('account_peppol_backport.ir_cron_peppol_get_message_status')._trigger()
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '!=', 'not_registered'), ('proxy_type', '=', 'peppol')])
+        edi_users = self.search([('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
+
+        # throughout the registration process, we need to check the status more frequently
+        if self.search_count([('company_id.account_peppol_proxy_state', '=', 'smp_registration')], limit=1):
+            self.env.ref('account_peppol_backport.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
 
     def _peppol_get_participant_status(self):
         for edi_user in self:
+            edi_user = edi_user.with_company(edi_user.company_id)
+            if edi_user.proxy_type != 'peppol':
+                continue
             try:
-                proxy_user = edi_user._make_request(
-                    f"{edi_user._get_server_url()}/api/peppol/1/participant_status")
+                proxy_user = edi_user._make_request(f"{edi_user._get_server_url()}/api/peppol/2/participant_status")
             except AccountEdiProxyError as e:
-                _logger.error('Error while updating Peppol participant status: %s', e)
+                if e.code == 'client_gone':
+                    # reset the connection if it was archived/deleted on IAP side
+                    edi_user.company_id.account_peppol_proxy_state = "not_registered"
+                    edi_user.sudo().unlink()
+                else:
+                    _logger.error('Error while updating Peppol participant status: %s', e)
                 continue
 
-            state_map = {
-                'active': 'active',
-                'verified': 'pending',
-                'rejected': 'rejected',
-                'canceled': 'canceled',
-            }
+            if 'error' in proxy_user:
+                error_message = proxy_user['error'].get('message') or proxy_user['error'].get('data', {}).get('message')
+                _logger.error('Error while updating Peppol participant status: %s', error_message)
+                continue
 
-            if proxy_user['peppol_state'] in state_map:
-                edi_user.company_id.account_peppol_proxy_state = state_map[proxy_user['peppol_state']]
+            local_state = {
+                'draft': 'not_registered',
+                'sender': 'sender',
+                'smp_registration': 'smp_registration',
+                'receiver': 'receiver',
+                'rejected': 'rejected',
+            }.get(proxy_user.get('peppol_state'))
+
+            if local_state:
+                edi_user.company_id.account_peppol_proxy_state = local_state
+            else:
+                _logger.warning("Received unknown Peppol state '%s' for EDI proxy user id=%s", proxy_user.get('peppol_state'), edi_user.id)
 
     def _peppol_send_document(self, invoice, xml_string: bytes, xml_filename: str):
         """Send one invoice or credit note to the Peppol Access Point.

--- a/account_peppol_backport/models/account_journal.py
+++ b/account_peppol_backport/models/account_journal.py
@@ -9,15 +9,16 @@ class AccountJournal(models.Model):
 
     def peppol_get_new_documents(self):
         edi_users = self.env['account_edi_proxy_client_peppol.user'].search([
-            ('company_id.account_peppol_proxy_state', '=', 'active'),
+            ('company_id.account_peppol_proxy_state', '=', 'receiver'),
             ('company_id', 'in', self.company_id.ids),
             ('proxy_type', '=', 'peppol')
         ])
         edi_users._peppol_get_new_documents()
 
     def peppol_get_message_status(self):
+        can_send = self.env['account_edi_proxy_client_peppol.user']._get_can_send_domain()
         edi_users = self.env['account_edi_proxy_client_peppol.user'].search([
-            ('company_id.account_peppol_proxy_state', '=', 'active'),
+            ('company_id.account_peppol_proxy_state', 'in', can_send),
             ('company_id', 'in', self.company_id.ids),
             ('proxy_type', '=', 'peppol')
         ])

--- a/account_peppol_backport/models/account_move.py
+++ b/account_peppol_backport/models/account_move.py
@@ -42,9 +42,10 @@ class AccountMove(models.Model):
 
     @api.depends('state')
     def _compute_peppol_move_state(self):
+        can_send = self.env['account_edi_proxy_client_peppol.user']._get_can_send_domain()
         for move in self:
             if all([
-                move.company_id.account_peppol_proxy_state == 'active',
+                move.company_id.account_peppol_proxy_state in can_send,
                 move.commercial_partner_id.account_peppol_is_endpoint_valid,
                 move.state == 'posted',
                 move.move_type in ('out_invoice', 'out_refund', 'out_receipt'),
@@ -69,7 +70,8 @@ class AccountMove(models.Model):
         invoice = render_context['record']
         invoice_country = invoice.commercial_partner_id.country_code
         company_country = invoice.company_id.country_code
-        company_on_peppol = invoice.company_id.account_peppol_proxy_state == 'active'
+        can_send = self.env['account_edi_proxy_client_peppol.user']._get_can_send_domain()
+        company_on_peppol = invoice.company_id.account_peppol_proxy_state in can_send
         if company_on_peppol and company_country in PEPPOL_MAILING_COUNTRIES and invoice_country in PEPPOL_MAILING_COUNTRIES:
             render_context['peppol_info'] = {
                 'peppol_country': invoice_country,

--- a/account_peppol_backport/models/res_company.py
+++ b/account_peppol_backport/models/res_company.py
@@ -65,12 +65,10 @@ class ResCompany(models.Model):
     account_peppol_proxy_state = fields.Selection(
         selection=[
             ('not_registered', 'Not registered'),
-            ('not_verified', 'Not verified'),
-            ('sent_verification', 'Verification code sent'),
-            ('pending', 'Pending'),
-            ('active', 'Active'),
+            ('sender', 'Can send but not receive'),
+            ('smp_registration', 'Can send, pending registration to receive'),
+            ('receiver', 'Can send and receive'),
             ('rejected', 'Rejected'),
-            ('canceled', 'Canceled'),
         ],
         string='PEPPOL status', required=True, default='not_registered',
     )
@@ -225,6 +223,44 @@ class ResCompany(models.Model):
     def write(self, vals):
         self._sanitize_peppol_endpoint_in_values(vals)
         return super().write(vals)
+
+    def _peppol_modules_document_types(self):
+        """Override this function to add supported document types as modules are installed.
+
+        :returns: dictionary of the form: {module_name: [(document identifier, document_name)]}
+        """
+        return {
+            'default': {
+                "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1":
+                    "Peppol BIS Billing UBL Invoice V3",
+                "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1":
+                    "Peppol BIS Billing UBL CreditNote V3",
+                "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:nen.nl:nlcius:v1.0::2.1":
+                    "SI-UBL 2.0 Invoice",
+                "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#compliant#urn:fdc:nen.nl:nlcius:v1.0::2.1":
+                    "SI-UBL 2.0 CreditNote",
+                "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:sg:3.0::2.1":
+                    "SG Peppol BIS Billing 3.0 Invoice",
+                "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:sg:3.0::2.1":
+                    "SG Peppol BIS Billing 3.0 Credit Note",
+                "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0::2.1":
+                    "XRechnung UBL Invoice V2.0",
+                "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0::2.1":
+                    "XRechnung UBL CreditNote V2.0",
+                "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0::2.1":
+                    "AU-NZ Peppol BIS Billing 3.0 Invoice",
+                "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0::2.1":
+                    "AU-NZ Peppol BIS Billing 3.0 CreditNote",
+            }
+        }
+
+    def _peppol_supported_document_types(self):
+        """Returns a flattened dictionary of all supported document types."""
+        return {
+            identifier: document_name
+            for module, identifiers in self._peppol_modules_document_types().items()
+            for identifier, document_name in identifiers.items()
+        }
 
     def _get_peppol_edi_mode(self):
         self.ensure_one()

--- a/account_peppol_backport/models/res_config_settings.py
+++ b/account_peppol_backport/models/res_config_settings.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
+
 from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError, ValidationError
 
@@ -57,6 +59,11 @@ class ResConfigSettings(models.TransientModel):
         selection=[('demo', 'Demo'), ('test', 'Test'), ('prod', 'Live')],
         compute='_compute_account_peppol_mode_constraint',
         help="Using the config params, this field specifies which edi modes may be selected from the UI"
+    )
+    account_peppol_smp_registration = fields.Boolean(
+        string='Register as a receiver',
+        help="If not check, you will only be able to send invoices but not receive them.",
+        compute='_compute_smp_registration',
     )
 
     # -------------------------------------------------------------------------
@@ -142,37 +149,25 @@ class ResConfigSettings(models.TransientModel):
                 config.account_peppol_endpoint_warning = _("The endpoint number might not be correct. "
                                                            "Please check if you entered the right identification number.")
 
-    # -------------------------------------------------------------------------
-    # BUSINESS ACTIONS
-    # -------------------------------------------------------------------------
+    @api.depends('account_peppol_eas', 'account_peppol_endpoint')
+    def _compute_smp_registration(self):
+        for config in self:
+            config.account_peppol_smp_registration = False
+            if config.account_peppol_eas and config.account_peppol_endpoint:
+                try:
+                    edi_identification = f'{config.account_peppol_eas}:{config.account_peppol_endpoint}'
+                    config._check_company_on_peppol(config.company_id, edi_identification)
+                    config.account_peppol_smp_registration = True
+                except UserError:  # pylint: disable=except-pass
+                    pass
 
     @handle_demo
-    def button_create_peppol_proxy_user(self):
-        """
-        The first step of the Peppol onboarding.
-        - Creates an EDI proxy user on the iap side, then the client side
-        - Calls /activate_participant to mark the EDI user as peppol user
-        """
-        self.ensure_one()
-
-        if self.account_peppol_proxy_state != 'not_registered':
-            raise UserError(
-                _('Cannot register a user with a %s application', self.account_peppol_proxy_state))
-
-        if not self.account_peppol_phone_number:
-            raise ValidationError(_("Please enter a mobile number to verify your application."))
-        if not self.account_peppol_contact_email:
-            raise ValidationError(_("Please enter a primary contact email to verify your application."))
-
-        company = self.company_id
-        edi_proxy_client = self.env['account_edi_proxy_client_peppol.user']
-        edi_identification = edi_proxy_client._get_proxy_identification(company, 'peppol')
-        company.partner_id._check_peppol_eas()
-
+    def _check_company_on_peppol(self, company, edi_identification):
         if (
-            (participant_info := company.partner_id._check_peppol_participant_exists(edi_identification, check_company=True))
-            and not self.account_peppol_migration_key
+            not company.account_peppol_migration_key
+            and company.partner_id._check_peppol_participant_exists(edi_identification, check_company=True)
         ):
+            participant_info = company.partner_id._peppol_lookup_participant(edi_identification)
             error_msg = _(
                 "A participant with these details has already been registered on the network. "
                 "If you have previously registered to a Peppol service, please deregister."
@@ -182,40 +177,143 @@ class ResConfigSettings(models.TransientModel):
                 error_msg += _("The Peppol service that is used is likely to be %s.", participant_info)
             raise UserError(error_msg)
 
-        edi_user = edi_proxy_client.sudo()._register_proxy_user(company, 'peppol', self.account_peppol_edi_mode)
-        self.account_peppol_proxy_state = 'not_verified'
-
-        # if there is an error when activating the participant below,
-        # the client side is rolled back and the edi user is deleted on the client side
-        # but remains on the proxy side.
-        # it is important to keep these two in sync, so commit before activating.
-        if not tools.config['test_enable'] and not modules.module.current_test:
-            self.env.cr.commit()  # pylint: disable=invalid-commit
-
-        company_details = {
-            'peppol_company_name': company.display_name,
-            'peppol_company_vat': company.vat,
-            'peppol_company_street': company.street,
-            'peppol_company_city': company.city,
-            'peppol_company_zip': company.zip,
-            'peppol_country_code': company.country_id.code,
-            'peppol_phone_number': self.account_peppol_phone_number,
-            'peppol_contact_email': self.account_peppol_contact_email,
+    def _get_company_details(self):
+        self.ensure_one()
+        return {
+            'peppol_company_name': self.company_id.display_name,
+            'peppol_company_vat': self.company_id.vat,
+            'peppol_company_street': self.company_id.street,
+            'peppol_company_city': self.company_id.city,
+            'peppol_company_zip': self.company_id.zip,
+            'peppol_country_code': self.company_id.country_id.code,
+            'peppol_phone_number': self.company_id.account_peppol_phone_number,
+            'peppol_contact_email': self.company_id.account_peppol_contact_email,
+            'peppol_migration_key': self.company_id.account_peppol_migration_key,
         }
 
+    def _peppol_register_sender(self):
+        self.ensure_one()
         params = {
-            'migration_key': self.account_peppol_migration_key,
-            'company_details': company_details,
+            'company_details': self._get_company_details(),
         }
+        self._call_peppol_proxy(
+            endpoint='/api/peppol/1/register_sender',
+            params=params,
+        )
+        self.company_id.account_peppol_proxy_state = 'sender'
+
+    def _peppol_register_sender_as_receiver(self):
+        self.ensure_one()
+        company = self.company_id
+
+        if company.account_peppol_proxy_state != 'sender':
+            # a participant can only try registering as a receiver if they are currently a sender
+            peppol_state_translated = dict(company._fields['account_peppol_proxy_state'].selection)[company.account_peppol_proxy_state]
+            raise UserError(
+                _('Cannot register a user with a %s application', peppol_state_translated))
+
+        edi_proxy_client = self.env['account_edi_proxy_client_peppol.user']
+        edi_identification = edi_proxy_client._get_proxy_identification(company, 'peppol')
+        self._check_company_on_peppol(company, edi_identification)
 
         self._call_peppol_proxy(
-            endpoint='/api/peppol/1/activate_participant',
-            params=params,
-            edi_user=edi_user,
+            endpoint='/api/peppol/1/register_sender_as_receiver',
+            params={
+                'migration_key': company.account_peppol_migration_key,
+                'supported_identifiers': list(company._peppol_supported_document_types())
+            },
         )
         # once we sent the migration key over, we don't need it
         # but we need the field for future in case the user decided to migrate away from Odoo
-        self.account_peppol_migration_key = False
+        company.account_peppol_migration_key = False
+        company.account_peppol_proxy_state = 'smp_registration'
+
+        self.env.ref('account_peppol_backport.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
+
+    def _peppol_deregister_participant(self):
+        self.ensure_one()
+
+        if self.company_id.account_peppol_proxy_state == 'receiver':
+            # fetch all documents and message statuses before unlinking the edi user
+            # so that the invoices are acknowledged
+            self.env['account_edi_proxy_client_peppol.user']._cron_peppol_get_message_status()
+            self.env['account_edi_proxy_client_peppol.user']._cron_peppol_get_new_documents()
+            if not tools.config['test_enable'] and not modules.module.current_test:
+                self.env.cr.commit()  # pylint: disable=invalid-commit
+
+        if self.company_id.account_peppol_proxy_state != 'not_registered':
+            self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')
+
+        self.company_id.account_peppol_proxy_state = 'not_registered'
+        self.company_id.account_peppol_migration_key = False
+        self.account_peppol_edi_user.unlink()
+
+    # -------------------------------------------------------------------------
+    # BUSINESS ACTIONS
+    # -------------------------------------------------------------------------
+
+    @handle_demo
+    def button_create_peppol_proxy_user(self):
+        """
+        The first step of the Peppol onboarding.
+        - Creates an EDI proxy user on the iap side, then the client side
+        - Register the user as sender
+        - Register the user as receiver if possible
+        """
+        self.ensure_one()
+
+        if self.account_peppol_proxy_state in ('smp_registration', 'receiver', 'rejected'):
+            raise UserError(
+                _('Cannot register a user with a %s application', self.account_peppol_proxy_state))
+
+        if not self.account_peppol_phone_number:
+            raise ValidationError(_("Please enter a mobile number to verify your application."))
+        if not self.account_peppol_contact_email:
+            raise ValidationError(_("Please enter a primary contact email to verify your application."))
+
+        company = self.company_id
+        edi_user = company.account_edi_proxy_client_peppol_ids.filtered(lambda u: u.proxy_type == 'peppol')
+        if not edi_user:
+            edi_proxy_client = self.env['account_edi_proxy_client_peppol.user']
+            edi_user = edi_proxy_client.sudo()._register_proxy_user(company, 'peppol', self.account_peppol_edi_mode)
+
+            # if there is an error when activating the participant below,
+            # the client side is rolled back and the edi user is deleted on the client side
+            # but remains on the proxy side.
+            # it is important to keep these two in sync, so commit before activating.
+            if not modules.module.current_test:
+                self.env.cr.commit()  # pylint: disable=invalid-commit
+
+        self._peppol_register_sender()
+
+        if self.account_peppol_smp_registration:
+            try:
+                self._peppol_register_sender_as_receiver()
+            except (UserError, AccountEdiProxyError):
+                self.button_deregister_peppol_participant()
+                raise
+
+        ## success
+        notifications = {
+            'sender': {
+                'message': _('You can now send electronic invoices via Peppol.'),
+            },
+            'smp_registration': {  # TODO remove in master
+                'message': _('Your Peppol registration will be activated soon. You can already send invoices.'),
+            },
+            'receiver': {
+                'message': _('You can now send and receive electronic invoices via Peppol'),
+            },
+        }
+        state = self.company_id.account_peppol_proxy_state
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': notifications[state]['message'],
+            }
+        }
 
     @handle_demo
     def button_update_peppol_user_data(self):
@@ -240,78 +338,37 @@ class ResConfigSettings(models.TransientModel):
             params=params,
         )
 
-    def button_send_peppol_verification_code(self):
+    @handle_demo
+    def button_peppol_smp_registration(self):
         """
-        Request user verification via SMS
-        Calls the /send_verification_code to send the 6-digit verification code
-        """
-        self.ensure_one()
-
-        # update contact details in case the user made changes
-        self.button_update_peppol_user_data()
-
-        self._call_peppol_proxy(
-            endpoint='/api/peppol/1/send_verification_code',
-            params={'message': _("Your confirmation code is")},
-        )
-        self.account_peppol_proxy_state = 'sent_verification'
-
-    def button_check_peppol_verification_code(self):
-        """
-        Calls /verify_phone_number to compare user's input and the
-        code generated on the IAP server
+        The second (optional) step in Peppol registration.
+        The user can choose to become a Receiver and officially register on the Peppol
+        network, i.e. receive documents from other Peppol participants.
         """
         self.ensure_one()
-
-        if len(self.account_peppol_verification_code) != 6:
-            raise ValidationError(_("The verification code should contain six digits."))
-
-        self._call_peppol_proxy(
-            endpoint='/api/peppol/1/verify_phone_number',
-            params={'verification_code': self.account_peppol_verification_code},
-        )
-        self.account_peppol_proxy_state = 'pending'
-        self.account_peppol_verification_code = False
-        # in case they have already been activated on the IAP side
-        self.env.ref('account_peppol_backport.ir_cron_peppol_get_participant_status')._trigger()
-
-    def button_cancel_peppol_registration(self):
-        """
-        Sets the peppol registration to canceled
-        - If the user is active on the SMP, we can't just cancel it.
-          They have to request a migration key using the `button_migrate_peppol_registration` action
-          or deregister.
-        - 'not_registered', 'rejected', 'canceled' proxy states mean that canceling the registration
-          makes no sense, so we don't do it
-        - Calls the IAP server first before setting the state as canceled on the client side,
-          in case they've been activated on the IAP side in the meantime
-        """
-        self.ensure_one()
-        # check if the participant has been already registered
-        self.account_peppol_edi_user._peppol_get_participant_status()
-        if not tools.config['test_enable'] and not modules.module.current_test:
-            self.env.cr.commit()  # pylint: disable=invalid-commit
-
-        if self.account_peppol_proxy_state == 'active':
-            raise UserError(_("Can't cancel an active registration. Please request a migration or deregister instead."))
-
-        if self.account_peppol_proxy_state in {'not_registered', 'rejected', 'canceled'}:
-            raise UserError(_(
-                "Can't cancel registration with this status: %s", self.account_peppol_proxy_state
-            ))
-
-        self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')
-        self.account_peppol_proxy_state = 'not_registered'
-        self.account_peppol_edi_user.unlink()
+        self._peppol_register_sender_as_receiver()
+        if self.account_peppol_proxy_state == 'smp_registration':
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': _("Registered to receive documents via Peppol."),
+                    'type': 'success',
+                    'message': _("Your registration on Peppol network should be activated within a day. The updated status will be visible in Settings."),
+                    'next': {'type': 'ir.actions.act_window_close'},
+                }
+            }
+        return True
 
     @handle_demo
     def button_migrate_peppol_registration(self):
         """
-        If the user is active, they need to request a migration key, generated on the IAP server.
+        Migrates AWAY from Odoo's SMP.
+        If the user is a receiver, they need to request a migration key, generated on the IAP server.
         The migration key is then displayed in Peppol settings.
         Currently, reopening after migrating away is not supported.
         """
-        raise UserError(_("This feature is deprecated. Contact odoo support if you need a migration key."))
+        raise UserError(_("This feature is deprecated. Contact Odoo support if you need a migration key."))
 
     @handle_demo
     def button_deregister_peppol_participant(self):
@@ -320,18 +377,6 @@ class ResConfigSettings(models.TransientModel):
         """
         self.ensure_one()
 
-        if self.account_peppol_proxy_state != 'active':
-            raise UserError(_(
-                "Can't deregister with this status: %s", self.account_peppol_proxy_state
-            ))
-
-        # fetch all documents and message statuses before unlinking the edi user
-        # so that the invoices are acknowledged
-        self.env['account_edi_proxy_client_peppol.user']._cron_peppol_get_message_status()
-        self.env['account_edi_proxy_client_peppol.user']._cron_peppol_get_new_documents()
-        if not tools.config['test_enable'] and not modules.module.current_test:
-            self.env.cr.commit()  # pylint: disable=invalid-commit
-
-        self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')
-        self.account_peppol_proxy_state = 'not_registered'
-        self.account_peppol_edi_user.unlink()
+        if self.account_peppol_edi_user:
+            self._peppol_deregister_participant()
+        return True

--- a/account_peppol_backport/readme/CONTRIBUTORS.md
+++ b/account_peppol_backport/readme/CONTRIBUTORS.md
@@ -1,1 +1,3 @@
 - Stéphane Bidoul <stephane.bidoul@acsone.eu>
+- [Coop IT Easy SC](https://coopiteasy.be):
+  - hugues de keyzer

--- a/account_peppol_backport/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/account_peppol_backport/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -9,18 +9,14 @@ import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-import { Component, markup, useState } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
 
-const waitTime = 60000;
 
 class PeppolSettingsButtons extends Component {
     setup() {
         super.setup();
         this.dialogService = useService("dialog");
         this.notification = useService("notification");
-        this.state = useState({
-            isSmsButtonDisabled: false,
-        });
     }
 
     get proxyState() {
@@ -28,11 +24,12 @@ class PeppolSettingsButtons extends Component {
     }
 
     get migrationPrepared() {
-        return this.props.record.data.account_peppol_proxy_state === "active" && Boolean(this.props.record.data.account_peppol_migration_key);
+        return this.props.record.data.account_peppol_proxy_state === "receiver" && Boolean(this.props.record.data.account_peppol_migration_key);
     }
 
     get ediMode() {
-        return this.props.record.data.account_peppol_edi_mode;
+        const demo_if_demo_identifier = this.props.record.data.peppol_eas === 'odemo' ? "demo": false
+        return demo_if_demo_identifier || this.props.record.data.edi_mode || this.props.record.data.account_peppol_edi_mode;
     }
 
     get modeConstraint() {
@@ -41,18 +38,15 @@ class PeppolSettingsButtons extends Component {
 
     get createUserButtonLabel() {
         const modes = {
-            demo: _t("Validate registration (Demo)"),
-            test: _t("Validate registration (Test)"),
-            prod: _t("Validate registration"),
+            demo: _t("Activate Peppol (Demo)"),
+            test: _t("Activate Peppol (Test)"),
+            prod: _t("Activate Peppol"),
         }
-        return modes[this.ediMode] || _t("Validate registration");
+        return modes[this.ediMode];
     }
 
     get deregisterUserButtonLabel() {
-        const modes = {
-            demo: _t("Switch to Live"),
-        }
-        return this.modeConstraint !== "demo" && modes[this.ediMode] || _t("Deregister from Peppol");
+        return _t("Remove from Peppol");
     }
 
     async _callConfigMethod(methodName, save = false) {
@@ -90,9 +84,9 @@ class PeppolSettingsButtons extends Component {
     }
 
     deregister() {
-        if (this.ediMode === 'demo') {
+        if (this.ediMode === 'demo' || !['sender', 'smp_registration', 'receiver'].includes(this.proxyState)) {
             this._callConfigMethod("button_deregister_peppol_participant");
-        } else {
+        } else if (['sender', 'smp_registration', 'receiver'].includes(this.proxyState)) {
             this.showConfirmation(
                 "This will delete your Peppol registration.",
                 "button_deregister_peppol_participant"
@@ -114,18 +108,11 @@ class PeppolSettingsButtons extends Component {
     async checkCode() {
         // Avoid making users click save on the settings
         // and then clicking the confirm button to check the code
-        await this._callConfigMethod("button_check_peppol_verification_code", true);
-    }
-
-    async sendCode() {
-        this.state.isSmsButtonDisabled = true;
-        // Don't allow spamming the button
-        setTimeout(() => this.state.isSmsButtonDisabled = false, waitTime); // eslint-disable-line
-        await this._callConfigMethod("button_send_peppol_verification_code", true);
-    }
-
-    async createUser() {
         await this._callConfigMethod("button_create_peppol_proxy_user", true);
+    }
+
+    async createReceiver() {
+        await this._callConfigMethod("button_peppol_smp_registration", true);
     }
 }
 

--- a/account_peppol_backport/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
+++ b/account_peppol_backport/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
@@ -6,8 +6,24 @@
             <div class="d-flex" colspan="3">
                 <div class="mt-3">
                     <button type="button"
-                            class="btn btn-primary"
-                            t-on-click="createUser"
+                            class="btn btn-primary me-1"
+                            t-on-click="createReceiver"
+                            t-if="proxyState === 'sender'">
+                            Allow reception
+                    </button>
+                </div>
+                <div class="mt-3">
+                    <button type="button"
+                            class="btn btn-secondary me-1"
+                            t-on-click="updateDetails"
+                            t-if="['sender', 'smp_registration', 'receiver'].includes(proxyState)">
+                            Update
+                    </button>
+                </div>
+                <div class="mt-3">
+                    <button type="button"
+                            class="btn btn-primary me-1"
+                            t-on-click="checkCode"
                             t-if="proxyState === 'not_registered'">
                             <t t-out="createUserButtonLabel"/>
                     </button>
@@ -16,41 +32,8 @@
                     <button type="button"
                             class="btn btn-secondary me-1"
                             t-on-click="deregister"
-                            t-if="proxyState === 'active' and migrationPrepared === false">
+                            t-if="['sender', 'smp_registration', 'receiver'].includes(proxyState) and migrationPrepared === false">
                             <t t-out="deregisterUserButtonLabel"/>
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <button type="button"
-                            class="btn btn-primary"
-                            t-on-click="updateDetails"
-                            t-if="['pending', 'manually_approved', 'active'].includes(proxyState)">
-                            Update contact details
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <button type="button"
-                            class="btn btn-primary"
-                            t-on-click="checkCode"
-                            t-if="proxyState === 'sent_verification'">
-                            Confirm
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <button type="button"
-                            class="btn btn-primary"
-                            t-on-click="sendCode"
-                            t-if="proxyState === 'not_verified'">
-                            Verify mobile number
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <button type="button"
-                            class="btn btn-secondary ms-1"
-                            t-on-click="sendCode"
-                            t-att-disabled="this.state.isSmsButtonDisabled"
-                            t-if="proxyState === 'sent_verification'">
-                            Send again
                     </button>
                 </div>
             </div>

--- a/account_peppol_backport/tools/demo_utils.py
+++ b/account_peppol_backport/tools/demo_utils.py
@@ -65,9 +65,12 @@ def _mock_make_request(func, self, *args, **kwargs):
     return {
         'ack': lambda _user, _args, _kwargs: {},
         'activate_participant': lambda _user, _args, _kwargs: {},
+        'register_sender': lambda _user, _args, _kwargs: {},
+        'register_receiver': lambda _user, _args, _kwargs: {},
+        'register_sender_as_receiver': lambda _user, _args, _kwargs: {},
         'get_all_documents': _mock_get_all_documents,
         'get_document': _mock_get_document,
-        'participant_status': lambda _user, _args, _kwargs: {'peppol_state': 'active'},
+        'participant_status': lambda _user, _args, _kwargs: {'peppol_state': 'receiver'},
         'send_document': _mock_send_document,
     }[endpoint](self, args, kwargs)
 
@@ -78,9 +81,7 @@ def _mock_button_verify_partner_endpoint(func, self, *args, **kwargs):
 
 def _mock_user_creation(func, self, *args, **kwargs):
     func(self, *args, **kwargs)
-    self.write({
-        'account_peppol_proxy_state': 'active',
-    })
+    self.account_peppol_proxy_state = 'receiver' if self.account_peppol_smp_registration else 'sender'
     self.account_peppol_edi_user.write({
         'private_key': b64encode(file_open(DEMO_PRIVATE_KEY, 'rb').read()),
     })
@@ -111,6 +112,10 @@ def _mock_deregister_participant(func, self, *args, **kwargs):
     self.account_peppol_proxy_state = 'not_registered'
     self.account_peppol_edi_mode = mode_constraint
 
+def _mock_smp_registration(func, self, *args, **kwargs):
+    func(self, *args, **kwargs)
+    self.account_peppol_proxy_state = 'receiver'
+
 
 def _mock_update_user_data(func, self, *args, **kwargs):
     pass
@@ -118,13 +123,18 @@ def _mock_update_user_data(func, self, *args, **kwargs):
 def _mock_migrate_participant(func, self, *args, **kwargs):
     self.account_peppol_migration_key = 'I9cz9yw*ruDM%4VSj94s'
 
+def _mock_check_company_on_peppol(func, self, *args, **kwargs):
+    pass
+
 _demo_behaviour = {
     '_make_request_peppol': _mock_make_request,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
     'button_create_peppol_proxy_user': _mock_user_creation,
     'button_deregister_peppol_participant': _mock_deregister_participant,
+    'button_peppol_smp_registration': _mock_smp_registration,
     'button_migrate_peppol_registration': _mock_migrate_participant,
     'button_update_peppol_user_data': _mock_update_user_data,
+    '_check_company_on_peppol': _mock_check_company_on_peppol,
 }
 
 # -------------------------------------------------------------------------

--- a/account_peppol_backport/views/account_journal_dashboard_views.xml
+++ b/account_peppol_backport/views/account_journal_dashboard_views.xml
@@ -12,8 +12,7 @@
                 </xpath>
 
                 <xpath expr="//t[@id='account.JournalBodySalePurchase']" position="inside">
-                    <t t-if="['active'].includes(record.account_peppol_proxy_state.raw_value)">
-                        <!-- XXX PEPPOL BACKPORT in v18, account_peppol_proxy_state can distinguish between sender, smp_registration and receiver -->
+                    <t t-if="['sender', 'smp_registration', 'receiver'].includes(record.account_peppol_proxy_state.raw_value)">
                         <t t-if="journal_type == 'sale'">
                             <div class="w-100">
                                 <a type="object" name="peppol_get_message_status" groups="account.group_account_invoice">Fetch Peppol invoice status</a>
@@ -22,10 +21,12 @@
                                 <a type="object" name="action_peppol_ready_moves" groups="account.group_account_invoice">Peppol ready invoices</a>
                             </div>
                         </t>
-                        <t t-elif="journal_type == 'purchase' and record.is_peppol_journal.raw_value">
-                            <div class="w-100">
-                                <a type="object" name="peppol_get_new_documents" groups="account.group_account_invoice">Fetch from Peppol</a>
-                            </div>
+                        <t t-elif="journal_type == 'purchase'">
+                            <t t-if="record.is_peppol_journal.raw_value and record.account_peppol_proxy_state.raw_value === 'receiver'">
+                                <div class="w-100">
+                                    <a type="object" name="peppol_get_new_documents" groups="account.group_account_invoice">Fetch from Peppol</a>
+                                </div>
+                            </t>
                         </t>
                     </t>
                 </xpath>

--- a/account_peppol_backport/views/res_config_settings_views.xml
+++ b/account_peppol_backport/views/res_config_settings_views.xml
@@ -50,7 +50,7 @@
                                 </div>
                             </div>
                             <div class="row"
-                                 attrs="{'invisible': [('account_peppol_proxy_state', 'not in', ['not_registered', 'not_verified'])]}">
+                                 attrs="{'invisible': [('account_peppol_proxy_state', '!=', 'not_registered')]}">
                                 <label string="Mobile Number"
                                        for="account_peppol_phone_number"
                                        class="col-lg-3 o_light_label"/>
@@ -58,7 +58,7 @@
                                        attrs="{'required': [('account_peppol_proxy_state', '=', 'not_verified')]}"/>
                             </div>
                             <div class="row"
-                                 attrs="{'invisible': [('account_peppol_proxy_state', 'in', ['rejected', 'canceled', 'sent_verification'])]}">
+                                 attrs="{'invisible': [('account_peppol_proxy_state', '=', 'rejected')]}">
                                 <label string="Primary contact email"
                                        for="account_peppol_contact_email"
                                        class="col-lg-3 o_light_label"/>
@@ -78,25 +78,13 @@
                             </div>
                             <div class="row mb-3">
                                 <div class="content-group mt-3"
-                                     attrs="{'invisible': [('account_peppol_proxy_state', 'in', ['rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification'])]}">
+                                     attrs="{'invisible': [('account_peppol_proxy_state', 'in', ['rejected', 'not_registered'])]}">
                                     <div class="row">
                                         <label string="Incoming Invoices Journal"
                                                for="account_peppol_purchase_journal_id"
                                                class="col-lg-3 o_light_label"/>
                                         <field name="account_peppol_purchase_journal_id"
-                                               attrs="{'required': [('account_peppol_proxy_state', 'not in', ['rejected', 'canceled', 'not_verified', 'not_registered', 'sent_verification'])]}"/>
-                                    </div>
-                                </div>
-                                <div class="content-group mt-3"
-                                     attrs="{'invisible': [('account_peppol_proxy_state', '!=', 'sent_verification')]}">
-                                    <span class="text-muted">
-                                        We sent a verification code to
-                                        <field name="account_peppol_phone_number"
-                                               nolabel="1"
-                                               attrs="{'readonly': [('account_peppol_proxy_state', '=', 'sent_verification')]}"/>.
-                                    </span>
-                                    <div class="row mt-1 ps-3">
-                                        <field name="account_peppol_verification_code" widget="verification_code"/>
+                                               attrs="{'required': [('account_peppol_proxy_state', 'not in', ['rejected', 'not_registered'])]}"/>
                                     </div>
                                 </div>
                                 <div class="pt-3 pb-3"
@@ -107,12 +95,12 @@
                                                class="oe_inline"
                                                readonly="1"
                                                decoration-danger="account_peppol_proxy_state == 'rejected'"
-                                               decoration-info="account_peppol_proxy_state == 'active'"/>
+                                               decoration-info="account_peppol_proxy_state in ('sender', 'smp_registration', 'receiver')"/>
                                         <span class="text-info" attrs="{'invisible': [('account_peppol_edi_mode', '!=', 'demo')]}"> (Demo)</span>
                                         <span class="text-info" attrs="{'invisible': [('account_peppol_edi_mode', '!=', 'test')]}"> (Test)</span>
                                     </b>
                                 </div>
-                                <div attrs="{'invisible': [('account_peppol_proxy_state', '!=', 'pending')]}">
+                                <div attrs="{'invisible': [('account_peppol_proxy_state', '!=', 'smp_registration')]}">
                                     <p>
                                         Your registration should be activated within a day.
                                     </p>
@@ -125,13 +113,13 @@
                                         Please do not hesitate to contact our support if you need further assistance.
                                     </p>
                                 </div>
-                                <div attrs="{'invisible': ['|', ('account_peppol_proxy_state', '!=', 'active'), ('account_peppol_migration_key', '=', False)]}">
+                                <div attrs="{'invisible': ['|', ('account_peppol_proxy_state', '!=', 'receiver'), ('account_peppol_migration_key', '=', False)]}">
                                     Your migration key is:
                                     <field name="account_peppol_migration_key"
                                            nolabel="1"
-                                           attrs="{'readonly': [('account_peppol_proxy_state', '=', 'active'), ('account_peppol_migration_key', '!=', False)]}"/>
+                                           attrs="{'readonly': [('account_peppol_proxy_state', '=', 'receiver'), ('account_peppol_migration_key', '!=', False)]}"/>
                                 </div>
-                                <div attrs="{'invisible': [('account_peppol_proxy_state', '!=', 'active')]}">
+                                <div attrs="{'invisible': [('account_peppol_proxy_state', 'not in', ('sender', 'smp_registration', 'receiver'))]}">
                                     Your Peppol identification is:
                                     <field name="account_peppol_edi_identification"
                                            nolabel="1"/>
@@ -151,15 +139,7 @@
                                     </div>
                                 </div>
                                 <div class="d-flex gap-1 action_buttons" colspan="3">
-                                    <widget name="peppol_settings_buttons"
-                                            attrs="{'invisible': [('account_peppol_proxy_state', 'not in', ['not_registered', 'not_verified', 'sent_verification', 'pending', 'manually_approved', 'active'])]}"/>
-                                    <div class="mt-3"
-                                         attrs="{'invisible': [('account_peppol_proxy_state', 'in', ['not_registered', 'active', 'rejected', 'canceled'])]}">
-                                        <button name="button_cancel_peppol_registration"
-                                                type="object"
-                                                string="Cancel registration"
-                                                class="btn btn-secondary"/>
-                                    </div>
+                                    <widget name="peppol_settings_buttons" />
                                 </div>
                             </div>
                         </div>

--- a/account_peppol_backport/wizard/account_invoice_send.py
+++ b/account_peppol_backport/wizard/account_invoice_send.py
@@ -74,8 +74,9 @@ class AccountInvoiceSend(models.TransientModel):
                 names,
             ))
         res["peppol_warning"] = "\n".join(peppol_warnings) if peppol_warnings else False
+        can_send = self.env['account_edi_proxy_client_peppol.user']._get_can_send_domain()
         res["enable_peppol"] = (
-            company.account_peppol_proxy_state == "active"
+            company.account_peppol_proxy_state in can_send
             and not peppol_warnings
         )
         if res["enable_peppol"]:


### PR DESCRIPTION
* avoid sms verification.
* allow to register only as sender.

i understand that this could make migration through 17.0 more difficult (as registration states are different), but i think being able to register as a sender only is a very useful feature to have.

tests still need to be fixed.