### PR TITLE
[FIX] account_peppol: CNAME to NAPTR migration

### DIFF
--- a/account_peppol_backport/models/res_partner.py
+++ b/account_peppol_backport/models/res_partner.py
@@ -61,6 +61,7 @@ class ResPartner(models.Model):
 
     @api.model
     def _get_participant_info(self, edi_identification):
+        # DEPRECATED: Peppol moved from CNAME to NAPTR DNS records
         hash_participant = md5(edi_identification.lower().encode()).hexdigest()
         endpoint_participant = parse.quote_plus(f"iso6523-actorid-upis::{edi_identification}")
         edi_mode = self.env.company._get_peppol_edi_mode()
@@ -76,18 +77,48 @@ class ResPartner(models.Model):
         return etree.fromstring(response.content)
 
     @api.model
+    def _peppol_lookup_participant(self, edi_identification):
+        """NAPTR DNS peppol participant lookup through Odoo's Peppol proxy"""
+        if (edi_mode := self.env.company._get_peppol_edi_mode()) == 'demo':
+            return
+
+        origin = self.env['account_edi_proxy_client_peppol.user']._get_proxy_urls()['peppol'][edi_mode]
+        query = parse.urlencode({'peppol_identifier': edi_identification.lower()})
+        endpoint = f'{origin}/api/peppol/1/lookup?{query}'
+
+        try:
+            response = requests.get(endpoint, timeout=TIMEOUT)
+        except requests.exceptions.RequestException as e:
+            _logger.debug("failed to query peppol participant %s: %s", edi_identification, e)
+            return
+
+        try:
+            decoded_response = response.json()
+        except requests.exceptions.JSONDecodeError:
+            _logger.error('invalid JSON response %s when querying peppol participant %s', response.status_code, edi_identification)
+            return
+
+        if error := decoded_response.get('error'):
+            if error.get('code') != 'NOT_FOUND':
+                _logger.error('error when querying peppol participant %s: %s', edi_identification, error.get('message', 'unknown error'))
+            return
+
+        return decoded_response.get('result')
+
+    @api.model
     def _check_peppol_participant_exists(self, edi_identification, check_company=False, ubl_cii_format=False):
-        participant_info = self._get_participant_info(edi_identification)
-        if participant_info is None:
+        if not (participant_info := self._peppol_lookup_participant(edi_identification)):
             return False
 
-        participant_identifier = participant_info.findtext('{*}ParticipantIdentifier')
-        service_metadata = participant_info.find('.//{*}ServiceMetadataReference')
-        service_href = ''
-        if service_metadata is not None:
-            service_href = service_metadata.attrib.get('href', '')
+        if services := participant_info.get('services'):
+            service_href = services[0].get('href', '')
+        else:
+            # participant exists and is registered, but doesn't expose any service
+            service_href = ''
 
-        if edi_identification != participant_identifier or 'hermes-belgium' in service_href:
+        participant_identifier = participant_info.get('identifier', '').lower()
+        # peppol identifier must be case insensitive
+        if edi_identification.lower() != participant_identifier or 'hermes-belgium' in service_href:
             # all Belgian companies are pre-registered on hermes-belgium, so they will
             # technically have an existing SMP url but they are not real Peppol participants
             return False
@@ -107,20 +138,30 @@ class ResPartner(models.Model):
 
         return self._check_document_type_support(participant_info, ubl_cii_format)
 
+
+    @api.model
+    def _get_customization_ids(self):
+        # On model 'account.edi.xml.ubl_21' in `account_edi_ubl_cii` in 17.0
+        # Moved here since we use the `ubl_cii_format` strings and not the 'account.edi.format' ones.
+        return {
+            'ubl_bis3': 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',
+            'nlcius': 'urn:cen.eu:en16931:2017#compliant#urn:fdc:nen.nl:nlcius:v1.0',
+            'xrechnung': 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0',
+        }
+
     def _check_document_type_support(self, participant_info, ubl_cii_format):
-        service_metadata = participant_info.find('.//{*}ServiceMetadataReferenceCollection')
-        if service_metadata is None:
-            return False
 
         # XXX PEPPOL BACKPORT
         # # document_type = self.env['account.edi.xml.ubl_21']._get_customization_ids()[ubl_cii_format]
         # In this backport we only support ubl_bis3 for now.
         if ubl_cii_format != 'ubl_bis3':
             return False
-        document_type = "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"
         # /XXX PEPPOL BACKPORT
-        for service in service_metadata.iterfind('{*}ServiceMetadataReference'):
-            if document_type in parse.unquote_plus(service.attrib.get('href', '')):
+
+        expected_customization_id = self._get_customization_ids()[ubl_cii_format]
+        for service in participant_info.get('services', []):
+            service_document_id = service.get('document_id')
+            if service_document_id and expected_customization_id in service_document_id:
                 return True
         return False
 
@@ -145,7 +186,7 @@ class ResPartner(models.Model):
                 partner.account_peppol_verification_label = 'not_verified'
             elif (
                 partner.is_peppol_edi_format
-                and (participant_info := self._get_participant_info(f'{partner.peppol_eas}:{partner.peppol_endpoint}'.lower())) is not None
+                and (participant_info := self._peppol_lookup_participant(f'{partner.peppol_eas}:{partner.peppol_endpoint}'.lower())) is not None
                 and not partner._check_document_type_support(participant_info, partner.ubl_cii_format)
             ):
                 # the partner might exist on the network, but not be able to receive that specific format
@@ -166,7 +207,8 @@ class ResPartner(models.Model):
         The SML (Service Metadata Locator) assigns a DNS name to each peppol participant.
         This DNS name resolves into the SMP (Service Metadata Publisher) of the participant.
         The DNS address is of the following form:
-        - "http://B-" + hexstring(md5(lowercase(ID-VALUE))) + "." + ID-SCHEME + "." + SML-ZONE-NAME + "/" + url_encoded(ID-SCHEME + "::" + ID-VALUE)
+        strip-trailing(base32(sha256(lowercase(ID-VALUE))),"=") + "." + ID-SCHEME + "." + SML-ZONE-NAME
+        The lookup should be done on NAPTR DNS from 2025-11-01
         (ref:https://peppol.helger.com/public/locale-en_US/menuitem-docs-doc-exchange)
         """
         self.ensure_one()

--- a/account_peppol_backport/tests/test_peppol_messages.py
+++ b/account_peppol_backport/tests/test_peppol_messages.py
@@ -1,6 +1,7 @@
 import json
 from base64 import b64encode
 from contextlib import contextmanager
+from urllib import parse
 
 from freezegun import freeze_time
 from requests import PreparedRequest, Response, Session
@@ -122,20 +123,55 @@ class TestPeppolMessage(RequestHandlerTransactionCase):
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
         response = Response()
         response.status_code = 200
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A0477472701'):
-            response._content = b"""<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:0477472701</id:ParticipantIdentifier>'
-            '<smp:ServiceMetadataReferenceCollection><smp:ServiceMetadataReference href="https://iap-services.odoo.com/iso6523-actorid-upis%3A%3A0208%3A0477472701/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1"/>'
-            '</smp:ServiceMetadataReferenceCollection></smp:ServiceGroup>"""
-            return response
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A3141592654'):
-            response.status_code = 404
-            return response
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A2718281828'):
-            response._content = b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:2718281828</id:ParticipantIdentifier></smp:ServiceGroup>'
-            return response
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0198%3Adk16356706'):
-            response._content = b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0198:dk16356706</id:ParticipantIdentifier></smp:ServiceGroup>'
-            return response
+
+        if r.path_url.startswith('/api/peppol/1/lookup'):
+            peppol_identifier = parse.parse_qs(r.path_url.rsplit('?')[1])['peppol_identifier'][0]
+            url_quoted_peppol_identifier = parse.quote_plus(peppol_identifier)
+            if peppol_identifier.endswith('0477472701'):
+                response.status_code = 200
+                response.json = lambda: {
+                    "result": {
+                        'identifier': peppol_identifier,
+                        'smp_base_url': "http://iap-services.odoo.com",
+                        'ttl': 60,
+                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
+                        'services': [
+                            {
+                                "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
+                                "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
+                            },
+                        ],
+                    },
+                }
+                return response
+            if peppol_identifier.endswith('3141592654'):
+                response.status_code = 404
+                response.json = lambda: {"error": {"code": "NOT_FOUND", "message": "no naptr record", "retryable": False}}
+                return response
+            if peppol_identifier.endswith('2718281828'):
+                response.status_code = 200
+                response.json = lambda: {
+                    "result": {
+                        'identifier': peppol_identifier,
+                        'smp_base_url': "http://iap-services.odoo.com",
+                        'ttl': 60,
+                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
+                        'services': [],
+                    },
+                }
+                return response
+
+            if peppol_identifier == '0198:dk16356706':
+                response.status_code = 200
+                response.json = lambda: {"result": {
+                        'identifier': peppol_identifier,
+                        'smp_base_url': "http://iap-services.odoo.com",
+                        'ttl': 60,
+                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
+                        'services': [],
+                    },
+                }
+                return response
 
         proxy_documents, responses = cls._get_mock_data(cls.env.context.get('error'))
         url = r.path_url

--- a/account_peppol_backport/tests/test_peppol_participant.py
+++ b/account_peppol_backport/tests/test_peppol_participant.py
@@ -1,5 +1,6 @@
 import json
 from contextlib import contextmanager
+from urllib.parse import parse_qs, quote_plus
 
 from freezegun import freeze_time
 from psycopg2 import IntegrityError
@@ -14,6 +15,12 @@ from .utils import RequestHandlerTransactionCase
 ID_CLIENT = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 FAKE_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
 PDF_FILE_PATH = 'account_peppol/tests/assets/peppol_identification_test.pdf'
+
+
+# SMP returns 200 for these and 404 otherwise
+
+SMP_OK_IDS = {'0208:0000000000', '0208:0000000001'}
+
 
 @freeze_time('2023-01-01')
 @tagged('-at_install', 'post_install')
@@ -53,12 +60,36 @@ class TestPeppolParticipant(RequestHandlerTransactionCase):
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
         response = Response()
         response.status_code = 200
-        if r.url.endswith('/iso6523-actorid-upis%3A%3A9925%3A0000000000'):
-            response.status_code = 404
-            return response
+        if r.path_url.startswith("/api/peppol/1/lookup"):
+            peppol_identifier = parse_qs(r.path_url.rsplit("?")[1])[
+                "peppol_identifier"
+            ][0]
 
-        if r.url.endswith('/iso6523-actorid-upis%3A%3A0208%3A0000000000'):
-            response._content = b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:0000000000</id:ParticipantIdentifier></smp:ServiceGroup>'
+            if peppol_identifier in SMP_OK_IDS:
+
+                response.json = lambda: {
+                    "result": {
+                        "identifier": peppol_identifier,
+                        "smp_base_url": "http://example.com/smp",
+                        "ttl": 60,
+                        "service_group_url": "http://example.com/smp/iso6523-actorid-upis%3A%3A"
+                        + quote_plus(peppol_identifier),
+                        "services": [],
+                    }
+                }
+
+            else:
+
+                response.status_code = 404
+
+                response.json = lambda: {
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": "no naptr record",
+                        "retryable": False,
+                    },
+                }
+
             return response
 
         url = r.path_url


### PR DESCRIPTION
From November 1st, CNAME DNS will be deprecated for Peppol lookups. From February 1st CNAME lookups will no longer be supported. The replacement are NAPTR DNS records.

Multiple solutions were available, such as using DoH (e.g. with cloudflare DNS), but we ended up choosing to proxy DNS requests through IAP to centralize the lookups and make such specs upgrades easier to handle in the future.

IAP is now responsible of doing the DNS lookup and fetching the service groups of the found SMP.
cherry-pick of: https://github.com/odoo/odoo/commit/e424742c721ff05ba83f71c422594d6b5b865b49