### PR TITLE
[16.0][FIX] fix update participant status

### DIFF
--- a/account_peppol_backport/models/account_edi_proxy_user.py
+++ b/account_peppol_backport/models/account_edi_proxy_user.py
@@ -262,7 +262,7 @@ class AccountEdiProxyClientPeppolUser(models.Model):
             self.env.ref('account_peppol_backport.ir_cron_peppol_get_message_status')._trigger()
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification']), ('proxy_type', '=', 'peppol')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '!=', 'not_registered'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
 
     def _peppol_get_participant_status(self):


### PR DESCRIPTION
the peppol registration state of a user on odoo’s iap server may change, and this status needs to be fetched regularly (and not only when a registration is pending).

most importantly: if a registered user doesn’t contact the iap server regularly (at least once a month), their registration will be deleted (information received from gauthier wala from odoo). without this change, requests to the iap server happens only when registered as a receiver and thus checking for new documents or when sending a document and checking for its status (but if this happens less often than once per month, deletion can happen).

backport of odoo/odoo#223418